### PR TITLE
Remove unused git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "distribute/packaging-templates"]
-	path = distribute/packaging-templates
-	url = https://github.com/stochsd/stochsd-packaging.git


### PR DESCRIPTION
The new version of the windows packager does not use submodules, so this PR removes the submodules from stochsd